### PR TITLE
Account select

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,6 +1,5 @@
 cluster:
   - "owens"
-  - "owens-slurm"
 form:
   - bc_account
   - bc_num_hours

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,14 +1,24 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
+---
 cluster:
   - "owens"
 form:
-  - bc_account
+  - account
   - bc_num_hours
   - num_cores
   - node_type
 attributes:
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+      <%- end %>
   num_cores:
     widget: "number_field"
     label: "Number of cores"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,21 +1,13 @@
 <%-
   ppn = num_cores.blank? ? 28 : num_cores.to_i
 
-  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
-
   slurm_args = [ "--nodes", "1", "--ntasks-per-node", "#{ppn}" ]
-  torque_args = "1:ppn=#{ppn}"
 %>
 ---
 batch_connect:
   template: vnc
 script:
   native:
-  <%- if torque_cluster %>
-    resources:
-      nodes: "<%= torque_args %>"
-  <%- else %>
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
-  <%- end %>
   <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -7,6 +7,7 @@
 batch_connect:
   template: vnc
 script:
+  accounting_id: "<%= account %>"
   native:
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"


### PR DESCRIPTION
This changes the account field to be a select widget for only valid project codes to help users only use valid project codes while forcing them to supply one.

It also removes all the now vestigial torque items.